### PR TITLE
Support concurrent application instances/checks

### DIFF
--- a/lib/heartcheck/checks/redis.rb
+++ b/lib/heartcheck/checks/redis.rb
@@ -24,7 +24,7 @@ module Heartcheck
       #
       # @return [Bollean]
       def set?(con)
-        con.set('check_test', 'heartcheck') == 'OK'
+        con.set(unique_check_key, 'heartcheck') == 'OK'
       end
 
       # test if can read on redis
@@ -33,7 +33,7 @@ module Heartcheck
       #
       # @return [Bollean]
       def get?(con)
-        con.get('check_test') == 'heartcheck'
+        con.get(unique_check_key) == 'heartcheck'
       end
 
       # test if can delete on redis
@@ -42,7 +42,7 @@ module Heartcheck
       #
       # @return [Bollean]
       def del?(con)
-        con.del('check_test') == 1
+        con.del(unique_check_key) == 1
       end
 
       # customize the error message
@@ -54,6 +54,15 @@ module Heartcheck
       # @return [void]
       def custom_error(name, key_error)
         @errors << "#{name} fails to #{key_error}"
+      end
+
+      # generate an unique redis key
+      # It's necessary to run concurrent application instances/checks using a
+      # shared redis
+      #
+      # @return [String]
+      def unique_check_key
+        @unique_check_key ||= SecureRandom.hex
       end
     end
   end

--- a/lib/heartcheck/redis.rb
+++ b/lib/heartcheck/redis.rb
@@ -1,3 +1,4 @@
 require 'redis'
+require 'securerandom'
 require 'heartcheck'
 require 'heartcheck/checks/redis'


### PR DESCRIPTION
# Motivation

Generally, we have many instances of the same application (for load balancing) and sometimes different applications sharing a single Redis data source.

In these scenarios, the checks randomly fail, depending on the order of `get`,` set`, `delete` competing between all instances.

# Proposal

Use unique keys when accessing Redis.