### PR TITLE
Require version of ruby >= 2.2.2 for allow use redis 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ matrix:
     - rvm: "2.3.0"
     - rvm: "2.3.3"
     - rvm: "2.4.1"
+    - rvm: "2.4.1"
+      gemfile: Gemfile-redis-3

--- a/Gemfile-redis-3
+++ b/Gemfile-redis-3
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'net-telnet', '~> 0.1.1'
+gem 'heartcheck', '>= 1.0.0'
+gem 'redis', '>= 3.2.0', '< 3.4.0'
+gem 'rack', '~> 1.6'
+gem 'rspec', '~> 3.1.0', '>= 3.1.0'
+gem 'pry-nav', '~> 0.2.0', '>= 0.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     heartcheck-redis (1.0.2)
       heartcheck (>= 1.0.0)
       net-telnet (~> 0.1.1)
-      redis (>= 3.2.0, < 3.4.0)
+      redis (>= 3.2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Heartcheck.setup do |config|
 end
 ```
 
+### For ruby old versions (older than ruby-2.2.2)
+
+If You are using an old version of Ruby, You may run Bundle's script with a specific gemfile.
+
+```shell
+    $ bundle install --gemfile=Gemfile-old-ruby
+```
+
 ### Check Heartcheck example [here](https://github.com/locaweb/heartcheck/blob/master/lib/heartcheck/generators/templates/config.rb)
 
 ## License

--- a/heartcheck-redis.gemspec
+++ b/heartcheck-redis.gemspec
@@ -17,10 +17,12 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec\//)
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.2.2'
+
   spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
 
   spec.add_dependency 'heartcheck', '>= 1.0.0'
-  spec.add_dependency 'redis', '>= 3.2.0', '< 3.4.0'
+  spec.add_dependency 'redis', '>= 3.2.0', '< 5'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2.0', '>= 0.2.4'
   spec.add_development_dependency 'rspec', '~> 3.1.0', '>= 3.1.0'


### PR DESCRIPTION
*Motiviation*

* Allow the use of versions 4.x of [redis-rb](https://github.com/redis/redis-rb)

*Proposal*

* Add minimum ruby version requirement
* Change limit for maximum version of `redis`
* Add instruction for using the `Gemfile-old-ruby` file for projects with ruby version older than 2.2.2

