### PR TITLE
Implement uri_info to comply with Inspect endpoint

### DIFF
--- a/lib/heartcheck/checks/redis.rb
+++ b/lib/heartcheck/checks/redis.rb
@@ -16,13 +16,18 @@ module Heartcheck
         end
       end
 
+      # list services uri info
+      #
+      # @return [Array]
       def uri_info
-        opts = services.first[:connection].connection
-        {
-          host: opts[:host],
-          port: opts[:port],
-          scheme: 'redis'.freeze
-        }
+        services.map do |s|
+          opts = s[:connection].connection
+          {
+            host: opts[:host],
+            port: opts[:port],
+            scheme: 'redis'.freeze
+          }
+        end
       end
 
       private

--- a/lib/heartcheck/checks/redis.rb
+++ b/lib/heartcheck/checks/redis.rb
@@ -21,7 +21,7 @@ module Heartcheck
         {
           host: opts[:host],
           port: opts[:port],
-          scheme: 'redis'
+          scheme: 'redis'.freeze
         }
       end
 

--- a/lib/heartcheck/checks/redis.rb
+++ b/lib/heartcheck/checks/redis.rb
@@ -16,6 +16,15 @@ module Heartcheck
         end
       end
 
+      def uri_info
+        opts = services.first[:connection].connection
+        {
+          host: opts[:host],
+          port: opts[:port],
+          scheme: 'redis'
+        }
+      end
+
       private
 
       # test if can write on redis

--- a/spec/heartcheck/checks/redis_spec.rb
+++ b/spec/heartcheck/checks/redis_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Heartcheck::Checks::Redis do
     end
   end
 
+  describe '#uri_info' do
+    context 'when a connection is set up' do
+      it 'returns proper URI data on connection settings' do
+        response = subject.uri_info
+        expect(response).to eq({ host: '127.0.0.1', port: 6379, scheme: 'redis'} )
+      end
+    end
+  end
+
   describe '#validate' do
     context 'when nothing fails' do
       it 'calls set get and delete' do

--- a/spec/heartcheck/checks/redis_spec.rb
+++ b/spec/heartcheck/checks/redis_spec.rb
@@ -9,10 +9,18 @@ RSpec.describe Heartcheck::Checks::Redis do
   end
 
   describe '#uri_info' do
-    context 'when a connection is set up' do
+    context 'when multiple servers are set up' do
+      before do
+        another_conn = ::Redis.new(url: 'redis://another.com:1234')
+        subject.add_service(name: 'another', connection: another_conn)
+      end
+
       it 'returns proper URI data on connection settings' do
         response = subject.uri_info
-        expect(response).to eq({ host: '127.0.0.1', port: 6379, scheme: 'redis'} )
+        expect(response).to eq([
+                                 { host: '127.0.0.1', port: 6379, scheme: 'redis' },
+                                 { host: 'another.com', port: 1234, scheme: 'redis' }
+                               ])
       end
     end
   end


### PR DESCRIPTION
This change overrides the generic method implemented by https://github.com/locaweb/heartcheck/pull/26

Signed-off-by: Luiz Cavalcanti <luiz.cavalcanti@locaweb.com.br>