### PR TITLE
update rake version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.1.1
+### Fixed
+- Update rake gem to >= 12.3.3
+
+## 2.1.0
+### Changed
+- Remove support for ruby < 2.5
+
 ## 2.1.0
 ### Changed
 - Remove support for ruby < 2.5

--- a/heartcheck-redis.gemspec
+++ b/heartcheck-redis.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redis', '>= 3.2.0', '< 5'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2', '>= 0.2.4'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '~> 0.52'
   # for documentation

--- a/lib/heartcheck/redis/version.rb
+++ b/lib/heartcheck/redis/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Redis
-    VERSION = '2.1.0'
+    VERSION = '2.1.1'
   end
 end


### PR DESCRIPTION
### Motivation

We need to update Rake gem following GitHub best practices.

### Proposed Solution

Update Rake gem version from `~> 10.0` to `>= 12.3.3`.
